### PR TITLE
Drop check for unused ImageCapture

### DIFF
--- a/js/camerainput.js
+++ b/js/camerainput.js
@@ -22,7 +22,7 @@
 /* global CFG_GLPI */
 /* global GLPI_PLUGINS_PATH */
 $(document).on('ready', function() {
-   if (typeof navigator.mediaDevices === 'undefined' || typeof navigator.mediaDevices.getUserMedia === 'undefined' || typeof ImageCapture === 'undefined') {
+   if (typeof navigator.mediaDevices === 'undefined' || typeof navigator.mediaDevices.getUserMedia === 'undefined') {
       return;
    }
 


### PR DESCRIPTION
ImageCapture is still not supported by many browsers and isn't even used by this plugin directly, and seems unused by the Quagga library. This may be causing the plugin to refuse to work even when it is technically possible.